### PR TITLE
Add Up and Down Arrows for Carousel Navigation

### DIFF
--- a/admin/static/css/style_index.css
+++ b/admin/static/css/style_index.css
@@ -700,13 +700,28 @@ a:focus {
 .client_section .owl-carousel .owl-nav .owl-next {
   width: 50px;
   height: 50px;
-  background-size: 18px;
-  background-position: center;
-  background-repeat: no-repeat;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   position: absolute;
-  right: -15%;
-  outline: none;
   background-color: #0a97b0;
+  outline: none;
+}
+
+.client_section .owl-carousel .owl-nav .owl-prev::before,
+.client_section .owl-carousel .owl-nav .owl-next::before {
+  font-family: "Font Awesome 6 Free";
+  font-weight: 900;
+  color: white;
+  font-size: 18px;
+}
+
+.client_section .owl-carousel .owl-nav .owl-prev::before {
+  content: "\f077"; /* Font Awesome Unicode for up arrow */
+}
+
+.client_section .owl-carousel .owl-nav .owl-next::before {
+  content: "\f078"; /* Font Awesome Unicode for down arrow */
 }
 
 .client_section .owl-carousel .owl-nav .owl-prev:hover,
@@ -715,13 +730,14 @@ a:focus {
 }
 
 .client_section .owl-carousel .owl-nav .owl-prev {
-  top: 25%;
-  background-image: url(../images/prev.png);
+  top: 10%;
+  right: -10%;
 }
 
 .client_section .owl-carousel .owl-nav .owl-next {
+  bottom: 10%;
+  right: -10%;
   top: calc(25% + 65px);
-  background-image: url(../images/next.png);
 }
 
 .contact_section {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues #77 

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](CONTRIBUTING.md)?

(Write your answer here.)


**Description: This PR updates the carousel navigation on the client section by adding up and down arrows instead of left and right, following the new design requirement. The arrows are placed to the right of the image box, with the "up" arrow at the top and the "down" arrow at the bottom.**

**Font Awesome Icons Added:

Used Font Awesome icons for up (\f077) and down (\f078) arrows.**
Applied CSS ::before pseudo-elements to render the icons inside the .owl-prev and .owl-next navigation buttons.
### before
![Screenshot 2024-10-12 005053](https://github.com/user-attachments/assets/ce62d835-0d92-46e5-9949-24de8da67d9d)
### after
![Screenshot 2024-10-18 021136](https://github.com/user-attachments/assets/58f0d3ca-0831-4a4e-b6a6-74eb0c73ce99)

